### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,22 +11,22 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "should": "^7.0.1",
-    "should-http": "^0.0.4",
-    "should-promised": "^0.3.0",
-    "should-sinon": "^0.0.3",
-    "sinon": "^1.15.3"
+    "should": "7.1.0",
+    "should-http": "0.0.4",
+    "should-promised": "0.3.1",
+    "should-sinon": "0.0.3",
+    "sinon": "1.17.1"
   },
   "devDependencies": {
-    "babel": "^5.6.5",
-    "babel-eslint": "^3.1.18",
-    "coveralls": "^2.11.2",
+    "babel": "5.8.23",
+    "babel-eslint": "3.1.30",
+    "coveralls": "2.11.4",
     "eslint": "0.23.0",
     "eslint-config-springworks": "2.1.2",
     "eslint-plugin-mocha": "0.3.0",
-    "eslint-plugin-should-promised": "^1.0.3",
-    "istanbul": "^0.3.16",
-    "mocha": "^2.2.5"
+    "eslint-plugin-should-promised": "1.0.4",
+    "istanbul": "0.3.21",
+    "mocha": "2.3.3"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
