### PR TITLE
Include mocha-teamcity-reporter as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "should-http": "0.0.4",
     "should-promised": "0.3.1",
     "should-sinon": "0.0.3",
-    "sinon": "1.17.1"
+    "sinon": "1.17.1",
+    "mocha-teamcity-reporter": "1.0.0"
   },
   "devDependencies": {
     "babel": "5.8.23",

--- a/teamcity-reporter.js
+++ b/teamcity-reporter.js
@@ -1,0 +1,1 @@
+module.exports = require('mocha-teamcity-reporter');


### PR DESCRIPTION
Can be used by other projects to get proper Teamcity test reporting.

Each repo should have 2 new scripts: `test-unit-ci`, `test-ci`
