### PR TITLE
Add API tester to configure static API

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,13 @@ describe('test-harness', () => {
 
   });
 
+  describe('run tests against static API', () => {
+
+    api_tester.configureStaticApi(data_store_api_static.createApiServer, config.get('test_helper.data_store_api.port'));
+
+    it('should be able to send request to static API and resolve without issues');
+
+  });
+
 });
 ```

--- a/api-tester.js
+++ b/api-tester.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+
+const api = {
+
+  configureStaticApi(apiServerCreator, port) {
+    assert(typeof apiServerCreator === 'function', 'apiServerCreator has to be function to create static api');
+    assert(port, 'Port has to be specified');
+
+    let server;
+
+    before(() => {
+      return apiServerCreator({ port: port }).then(created_server => {
+        server = created_server;
+        return server.start();
+      });
+    });
+
+    after(() => {
+      return server.stop();
+    });
+  },
+
+};
+
+// exported in a way that is compatible with both `require` and `import`
+module.exports = api;
+module.exports.default = api;
+Object.defineProperty(module.exports, '__esModule', { value: true });


### PR DESCRIPTION
Makes it easier to handle running of static API:s. This might be something that could equally be copy-pasted across projects (not all projects have the need to run static APIs, so test harness _could_ be too generic).

---

**Example**

``` js
describe('./test.js', () => {

  // will configure start, and stop the static api using before/after
  api_tester.configureStaticApi(data_store_api_static.createApiServer, config.get('test_helper.data_store_api.port'));

}
```
