### PR TITLE
fix: Add missing "use strict" to api tester

### DIFF
--- a/api-tester.js
+++ b/api-tester.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 const api = {


### PR DESCRIPTION
Ensures that `const` and `let` can be used properly.
