### PR TITLE
Revert "Add sinon-as-promised"

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ global.should = require('should').noConflict();
 global.should.extend();
 
 global.sinon = require('sinon');
-global.sinonAsPromised = require('sinon-as-promised');
 
 require('should-sinon');
 require('should-http');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "should-http": "0.0.4",
     "should-sinon": "0.0.5",
     "sinon": "1.17.4",
-    "sinon-as-promised": "4.0.2",
     "mocha-teamcity-reporter": "1.0.2"
   },
   "devDependencies": {

--- a/test/test-harness-test.js
+++ b/test/test-harness-test.js
@@ -32,18 +32,6 @@ describe('test/test-harness-test.js', () => {
 
   });
 
-  describe('stubbing promises', () => {
-
-    it('should use the sinon-as-promised plugin', done => {
-      const test_stub = sinon.stub().resolves('foo');
-      test_stub().then(value => {
-        value.should.equal('foo');
-        done();
-      });
-    });
-
-  });
-
   describe('asserting http requests', () => {
 
     it('should use the should-http plugin', () => {


### PR DESCRIPTION
Reverts Springworks/node-test-harness#198

This broke a lot of tests for odd reasons. Reverting is the fast path ahead.
