### PR TITLE
fix(package): remove overriding of `analyzeCommits`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "greenkeeper-postpublish": "^1.0.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
-    "pre-git": "3.14.1",
+    "pre-git": "^3.15.3",
     "semantic-release": "^8.0.3"
   },
   "config": {
@@ -50,9 +50,6 @@
     "url": "https://github.com/Springworks/node-test-harness/issues"
   },
   "homepage": "https://github.com/Springworks/node-test-harness#readme",
-  "release": {
-    "analyzeCommits": "simple-commit-message"
-  },
   "engines": {
     "node": "6"
   }


### PR DESCRIPTION
Hoping that this will make it possible for semantic-release to actually deploy... Not crystal clear to me how https://github.com/semantic-release/commit-analyzer/ should be configured, but looking at other projects we have this is one thing that differs.