### PR TITLE
fix(typescript): add return type to configureStaticApi()

### DIFF
--- a/api-tester.d.ts
+++ b/api-tester.d.ts
@@ -1,1 +1,1 @@
-export function configureStaticApi(apiServerCreator: Function, port: number);
+export function configureStaticApi(apiServerCreator: Function, port: number): void;


### PR DESCRIPTION
Complained about assuming it was Any.