### PR TITLE
fix(package): keep sinon types and package in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "should": "^13.2.3",
     "should-http": "^0.1.0",
     "should-sinon": "^0.0.6",
-    "sinon": "^6.1.4"
+    "sinon": "^5.0.1"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.6",


### PR DESCRIPTION
No new types available beyond 5.0.1; staying there to keep in sync.